### PR TITLE
Use SSH url for gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "rdkafka-sys/librdkafka"]
 	path = rdkafka-sys/librdkafka
-	url = https://github.com/getditto/librdkafka
+	url = git@github.com:getditto/librdkafka.git


### PR DESCRIPTION
This ensures that cargo can clone the repo as a submodule using SSH agent auth in CI.